### PR TITLE
Removed duplicate closing tag on title in .library xml

### DIFF
--- a/generators/app/templates/src/baselibrary/_.library
+++ b/generators/app/templates/src/baselibrary/_.library
@@ -4,7 +4,7 @@
     <vendor>SAP SE</vendor>
     <version>1.0.0</version>
     <copyright>${copyright}</copyright>
-    <title>><%= libraryname %></title>
+    <title><%= libraryname %></title>
     <documentation><%= libraryname %></documentation>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Hey there 👋

saw that there was a closing tag too much and don't think it belongs there. 

Awesome generator! Takes away lots of manual effort 🥳 

Greetings,
Marco