### PR TITLE
Fix: base theme template

### DIFF
--- a/generators/app/templates/src/baselibrary/themes/base/library.source.less
+++ b/generators/app/templates/src/baselibrary/themes/base/library.source.less
@@ -1,4 +1,5 @@
-@import "/resources/sap/ui/core/themes/base/global.css";
+@import "/resources/sap/ui/core/themes/base/base.less";
+@import "/resources/sap/ui/core/themes/base/global.less";
 
 @import "shared.less";
 @import "Example.less";


### PR DESCRIPTION
Hey there 👋

I found two minor "bugs".

- wrong file extension from .css to .less

currently you'd get the following error (css instead of less)
![image](https://user-images.githubusercontent.com/14982812/106802665-8be88900-6663-11eb-8872-ce8d2b88fa57.png)

- added missing `base.less` file import from `sap.ui.core.themes`

once the first error is fixed, you need to add base.less in order to be able to build the library:
![image](https://user-images.githubusercontent.com/14982812/106802761-af133880-6663-11eb-94ff-a5f897f1d467.png)

Additional information regarding the theming I found [here](https://github.com/SAP/openui5/blob/dc225e1c87bcdfe64e6c67972f6a7bd561cc00d7/docs/controllibraries.md#themes-librarysourceless-sharedcss-img-img-rtl)

Sidenote: I only adjusted the apiVersion of the renderer (doubt it has anything to do with it, just mentioning it), nothing else within the library itself here, just the bare yeoman generated library. 

Best Regards,
Marco 🐛

